### PR TITLE
chore(ci): replace deprecated set-output workflow command (FIR-23850)

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -24,7 +24,7 @@ jobs:
         run: ./gradlew build
       - name: Get Release Version
         id: get_version
-        run: VERSION=$(./gradlew currentVersion -q -Prelease.quiet) && echo ::set-output name=VERSION::$VERSION
+        run: VERSION=$(./gradlew currentVersion -q -Prelease.quiet) && echo VERSION="${VERSION}" >> "${GITHUB_OUTPUT}"
       - name: Upload git-plugin jar
         uses: actions/upload-artifact@v1.0.0
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
         run: ./gradlew build
       - name: Get Release Version
         id: get_version
-        run: VERSION=$(./gradlew currentVersion -q -Prelease.quiet) && echo ::set-output name=VERSION::$VERSION
+        run: VERSION=$(./gradlew currentVersion -q -Prelease.quiet) && echo VERSION="${VERSION}" >> "${GITHUB_OUTPUT}"
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1.0.0


### PR DESCRIPTION
**Background**

[FIR-23850](https://packboard.atlassian.net/browse/FIR-23850): `set-output` was supposed to be deprecated 31 May (in 5 days). They delayed, but it needs done anyway

**Details**

https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

**Testing**

It's a drop in replacement, eyeball scan for typos should do.

[FIR-23850]: https://packboard.atlassian.net/browse/FIR-23850?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ